### PR TITLE
fix: source file extenstion behaviour

### DIFF
--- a/src/ffmpeg2obj/script.py
+++ b/src/ffmpeg2obj/script.py
@@ -300,7 +300,9 @@ def get_processed_files(
     processed_files = []
     for object_name, real_paths in source_files.items():
         if source_file_extension != target_file_extension:
-            target_object_name = object_name.replace(source_file_extension, target_file_extension)
+            target_object_name = object_name.replace(
+                source_file_extension, target_file_extension
+            )
         else:
             target_object_name = object_name
         is_uploaded = target_object_name in bucket_objects


### PR DESCRIPTION
realised that post conversion/upload stored files would use object name containing source file extension and not target (effective) one - this alleviates that